### PR TITLE
perf: improve import alias mapping performance

### DIFF
--- a/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease.Datamigration.PowerShellModule/Azure.DevOps.Extensions.XrmRelease.Datamigration.PowerShellModule.csproj
+++ b/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease.Datamigration.PowerShellModule/Azure.DevOps.Extensions.XrmRelease.Datamigration.PowerShellModule.csproj
@@ -33,26 +33,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.11\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.13\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.11\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.13\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataScrambler, Version=3.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.11\lib\net462\Capgemini.DataScrambler.dll</HintPath>
+    <Reference Include="Capgemini.DataScrambler, Version=3.1.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.13\lib\net462\Capgemini.DataScrambler.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.11\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.13\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.11\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.13\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.11\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.13\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.11\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.13\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
     </Reference>
     <Reference Include="CsvHelper, Version=9.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CsvHelper.9.2.3\lib\net45\CsvHelper.dll</HintPath>

--- a/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease.Datamigration.PowerShellModule/packages.config
+++ b/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease.Datamigration.PowerShellModule/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.11" targetFramework="net462" />
+  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.13" targetFramework="net462" />
   <package id="CsvHelper" version="9.2.3" targetFramework="net462" />
   <package id="log4net" version="2.0.8" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.34" targetFramework="net462" />

--- a/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease/Extensions/XrmRelease/Tasks/DataExporter/task.json
+++ b/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease/Extensions/XrmRelease/Tasks/DataExporter/task.json
@@ -11,15 +11,12 @@
   "author": "capgemini-uk",
   "version": {
     "Major": 0,
-    "Minor": 15,
+    "Minor": 16,
     "Patch": 0
   },
-  "demands": [
-  ],
+  "demands": [],
   "minimumAgentVersion": "1.83.0",
-  "groups": [
-
-  ],
+  "groups": [],
   "inputs": [
     {
       "name": "batchSize",

--- a/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease/Extensions/XrmRelease/Tasks/DataImporter/task.json
+++ b/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease/Extensions/XrmRelease/Tasks/DataImporter/task.json
@@ -11,15 +11,12 @@
   "author": "capgemini-uk",
   "version": {
     "Major": 0,
-    "Minor": 14,
+    "Minor": 15,
     "Patch": 0
   },
-  "demands": [
-  ],
+  "demands": [],
   "minimumAgentVersion": "1.83.0",
-  "groups": [
-
-  ],
+  "groups": [],
   "inputs": [
     {
       "name": "jsonFolderPath",

--- a/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease/Extensions/XrmRelease/vss-extension.json
+++ b/Azure.DevOps.Extensions.XrmRelease/Azure.DevOps.Extensions.XrmRelease/Extensions/XrmRelease/vss-extension.json
@@ -1,9 +1,12 @@
 {
   "manifestVersion": 1,
   "id": "xrm-release",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "name": "Capgemini Release Tasks for Dynamics 365",
-  "scopes": [ "vso.build", "vso.code_write" ],
+  "scopes": [
+    "vso.build",
+    "vso.code_write"
+  ],
   "description": "Tasks for releasing into and managing Dynamics 365 instances.",
   "publisher": "capgemini-uk",
   "public": false,


### PR DESCRIPTION
This will cache results returned from lookup alias mapping. For example, if we're mapping the owner of records to a system user with a given email, it will no longer make one request per record (assuming they're all mapping to the same email). This can result in drastic performance improvements for large data sets mapping to a small table e.g. systemusers.

See https://github.com/Capgemini/xrm-datamigration/commit/b2381c76a4feeb7cd275aed6b0fb5885177fe107.